### PR TITLE
Potential fix for code scanning alert no. 3: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/main/java/com/kelsoncm/libs/util/ZipUtils.java
+++ b/src/main/java/com/kelsoncm/libs/util/ZipUtils.java
@@ -238,14 +238,34 @@ public final class ZipUtils {
         try {
             zipFile = new ZipFile(nomZip);
             final Enumeration<? extends ZipEntry> enumeration = zipFile.entries();
+            final File diretorioBase = new File(dirTemp).getCanonicalFile();
+            final String diretorioBasePath = diretorioBase.getPath();
 
             try {
                 while (enumeration.hasMoreElements()) {
                     final ZipEntry zipEntry = enumeration.nextElement();
-                    final String nomeCompletoZip = dirTemp + System.getProperty("file.separator") + zipEntry.getName();
-                    final OutputStream outStream = new FileOutputStream(nomeCompletoZip);
+                    final File arquivoDestino = new File(diretorioBase, zipEntry.getName()).getCanonicalFile();
+                    final String arquivoDestinoPath = arquivoDestino.getPath();
+                    if (!(arquivoDestinoPath.equals(diretorioBasePath)
+                            || arquivoDestinoPath.startsWith(diretorioBasePath + File.separator))) {
+                        throw new IOException("Entrada de ZIP inválida: " + zipEntry.getName());
+                    }
+
+                    if (zipEntry.isDirectory()) {
+                        if (!arquivoDestino.exists() && !arquivoDestino.mkdirs()) {
+                            throw new IOException("Não foi possível criar diretório: " + arquivoDestinoPath);
+                        }
+                        continue;
+                    }
+
+                    final File parent = arquivoDestino.getParentFile();
+                    if (parent != null && !parent.exists() && !parent.mkdirs()) {
+                        throw new IOException("Não foi possível criar diretório: " + parent.getPath());
+                    }
+
+                    final OutputStream outStream = new FileOutputStream(arquivoDestino);
                     final InputStream inStream = zipFile.getInputStream(zipEntry);
-                    resultado.add(nomeCompletoZip);
+                    resultado.add(arquivoDestinoPath);
                     try {
                         while ((length = inStream.read(buffer)) != -1) {
                             outStream.write(buffer, 0, length);


### PR DESCRIPTION
Potential fix for [https://github.com/kelsoncm/java-fwf/security/code-scanning/3](https://github.com/kelsoncm/java-fwf/security/code-scanning/3)

A correção correta é validar cada entrada do ZIP contra o diretório de destino **antes** de qualquer operação de escrita, garantindo que o caminho final normalizado/canônico permaneça dentro de `dirTemp`.

Melhor abordagem neste arquivo:
1. Em `descompactar`, criar um `File` base canônico para `dirTemp`.
2. Para cada `ZipEntry`, construir `File destino = new File(baseDir, zipEntry.getName())` e obter `destinoCan = destino.getCanonicalFile()`.
3. Verificar se `destinoCan.getPath()` começa com `baseDir.getPath() + File.separator` (ou é exatamente `baseDir`), caso contrário lançar `IOException`.
4. Tratar diretórios (`zipEntry.isDirectory()`): criar diretórios e não abrir stream de arquivo.
5. Garantir criação do diretório pai para arquivos.
6. Gravar usando `destinoCan` e adicionar `destinoCan.getPath()` em `resultado`.

Isso elimina o Zip Slip e também neutraliza o segundo alerta (linha 291), pois a lista `resultado` passará a conter somente caminhos previamente validados dentro de `dirTemp`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
