### PR TITLE
Potential fix for code scanning alert no. 4: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/main/java/com/kelsoncm/libs/util/ZipUtils.java
+++ b/src/main/java/com/kelsoncm/libs/util/ZipUtils.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -239,17 +240,17 @@ public final class ZipUtils {
             zipFile = new ZipFile(nomZip);
             final Enumeration<? extends ZipEntry> enumeration = zipFile.entries();
             final File diretorioBase = new File(dirTemp).getCanonicalFile();
-            final String diretorioBasePath = diretorioBase.getPath();
+            final Path diretorioBaseNormalizado = diretorioBase.toPath().toAbsolutePath().normalize();
 
             try {
                 while (enumeration.hasMoreElements()) {
                     final ZipEntry zipEntry = enumeration.nextElement();
-                    final File arquivoDestino = new File(diretorioBase, zipEntry.getName()).getCanonicalFile();
-                    final String arquivoDestinoPath = arquivoDestino.getPath();
-                    if (!(arquivoDestinoPath.equals(diretorioBasePath)
-                            || arquivoDestinoPath.startsWith(diretorioBasePath + File.separator))) {
+                    final Path arquivoDestinoNormalizado = diretorioBaseNormalizado.resolve(zipEntry.getName()).normalize();
+                    if (!arquivoDestinoNormalizado.startsWith(diretorioBaseNormalizado)) {
                         throw new IOException("Entrada de ZIP inválida: " + zipEntry.getName());
                     }
+                    final File arquivoDestino = arquivoDestinoNormalizado.toFile();
+                    final String arquivoDestinoPath = arquivoDestino.getPath();
 
                     if (zipEntry.isDirectory()) {
                         if (!arquivoDestino.exists() && !arquivoDestino.mkdirs()) {


### PR DESCRIPTION
Potential fix for [https://github.com/kelsoncm/java-fwf/security/code-scanning/4](https://github.com/kelsoncm/java-fwf/security/code-scanning/4)

A correção ideal é validar a entrada do ZIP com `java.nio.file.Path` (normalização + checagem por segmentos com `Path.startsWith`) antes de criar diretórios/arquivos. Isso evita ambiguidades de comparação por `String` e cobre os três alertas (linhas 255, 262 e 266), porque todos dependem do mesmo `arquivoDestino`.

No arquivo `src/main/java/com/kelsoncm/libs/util/ZipUtils.java`, na região do método `descompactar`, substitua a lógica de validação atual (`diretorioBasePath`/`arquivoDestinoPath` com `String.startsWith`) por:
- `Path diretorioBaseNormalizado = diretorioBase.toPath().toAbsolutePath().normalize();`
- `Path arquivoDestinoNormalizado = diretorioBaseNormalizado.resolve(zipEntry.getName()).normalize();`
- validação `if (!arquivoDestinoNormalizado.startsWith(diretorioBaseNormalizado)) throw ...;`
- só depois converter para `File` com `arquivoDestinoNormalizado.toFile()` e continuar fluxo atual.

Também é necessário adicionar import de `java.nio.file.Path`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
