### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/main/java/com/kelsoncm/libs/util/ZipUtils.java
+++ b/src/main/java/com/kelsoncm/libs/util/ZipUtils.java
@@ -200,15 +200,24 @@ public final class ZipUtils {
         final ZipInputStream zin = new ZipInputStream(inputStream);
         ZipEntry zipEntry = null;
         String nomeArquivo = STRING_EMPTY;
+        final File diretorioSaida = new File(diretorioDestino).getCanonicalFile();
 
         FileOutputStream fout = null;
         try {
             while ((zipEntry = zin.getNextEntry()) != null) {
                 nomeArquivo = zipEntry.getName();
-                final String nomeCompletoArquivo = diretorioDestino + System.getProperty("file.separator")
-                        + nomeArquivo;
+                final File arquivoSaida = new File(diretorioSaida, nomeArquivo).getCanonicalFile();
 
-                fout = new FileOutputStream(nomeCompletoArquivo);
+                if (!arquivoSaida.toPath().startsWith(diretorioSaida.toPath())) {
+                    throw new IOException("Entrada ZIP inválida: " + nomeArquivo);
+                }
+
+                final File parent = arquivoSaida.getParentFile();
+                if (parent != null && !parent.exists()) {
+                    parent.mkdirs();
+                }
+
+                fout = new FileOutputStream(arquivoSaida);
 
                 for (int c = zin.read(); c != -1; c = zin.read()) {
                     fout.write(c);


### PR DESCRIPTION
Potential fix for [https://github.com/kelsoncm/java-fwf/security/code-scanning/1](https://github.com/kelsoncm/java-fwf/security/code-scanning/1)

A correção deve replicar no método `descompactar` a mesma estratégia segura já usada em `descompactarPrimeiroArquivo`: resolver diretório de saída e arquivo de saída como canônicos e garantir que o arquivo final permaneça dentro do diretório base antes de abrir `FileOutputStream`.

Melhor ajuste sem alterar funcionalidade:
- Em `src/main/java/com/kelsoncm/libs/util/ZipUtils.java`, dentro de `descompactar(...)`:
  - Remover a concatenação de string para caminho (`nomeCompletoArquivo`).
  - Criar `File diretorioSaida = new File(diretorioDestino).getCanonicalFile();`
  - Para cada entry, criar `File arquivoSaida = new File(diretorioSaida, nomeArquivo).getCanonicalFile();`
  - Validar: `if (!arquivoSaida.toPath().startsWith(diretorioSaida.toPath())) throw new IOException(...)`
  - Criar diretórios-pai quando necessário.
  - Abrir `FileOutputStream` com `arquivoSaida`.
- Não precisa dependência nova; imports já existentes são suficientes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
